### PR TITLE
uncomment Excluded JS/CSS for JS compression in templateDetails.xml

### DIFF
--- a/meet_gavern/templateDetails.xml
+++ b/meet_gavern/templateDetails.xml
@@ -523,7 +523,7 @@
                                                   <option	value="1">TPL_GK_LANG_ENABLED</option>
                                         </field>
                                         
-                                        <!--<field name="jscss_excluded" type="textarea" rows="3" cols="30" label="TPL_GK_LANG_EXCLUDEJSCSS" description="TPL_GK_LANG_EXCLUDEJSCSS_DESC" />-->
+                                        <field name="jscss_excluded" type="textarea" rows="3" cols="30" label="TPL_GK_LANG_EXCLUDEJSCSS" description="TPL_GK_LANG_EXCLUDEJSCSS_DESC" />
                                         
                                         <field name="css_custom" type="textarea" rows="6" cols="40" label="TPL_GK_LANG_CSS_CUSTOM" description="TPL_GK_LANG_CSS_CUSTOM_DESC" />
                                         <field name="gk_line_13" type="line" text="" />


### PR DESCRIPTION
Hi, when doing the dutch translation I translated a field that I didn't find in the template manager: jscss_excluded
been working on the SEO of my website and enabled JavaScript compression just to find out that one js script stopped working... I want to use JavaScript compression AND exclude this one script.

Found out that the jscss_excluded was commented out from templateDetails.xml. this pull request is to get it back in and working.

Just to let you know that it actually works :) got my Google pagespeed insight up to 95/100!!!
