### PR TITLE
fixes featured, category layout and improves og:image implementation

### DIFF
--- a/meet_gavern/html/com_content/article/default.php
+++ b/meet_gavern/html/com_content/article/default.php
@@ -36,11 +36,19 @@ $og_url = $cur_url;
 if (isset($images->image_fulltext) and !empty($images->image_fulltext)) {     $og_image = $uri->root() . htmlspecialchars($images->image_fulltext);
      $pin_image = $uri->root() . htmlspecialchars($images->image_fulltext);
 } else {
-     $og_image = '';
-     preg_match('/src="([^"]*)"/', $this->item->text, $matches);
+     $templateParams = JFactory::getApplication()->getTemplate(true)->params;
+     $og_image = $uri->root() . $templateParams->get('logo_image','');
+     preg_match('/src="([^"]*)"/', $this->item->introtext, $matches);
+     $ext = substr($matches[0], -5, -1);
      
-     if(isset($matches[0])) {
-     	$pin_image = $uri->root() . substr($matches[0], 5,-1);
+     if(isset($matches[0]) && ($ext == ".jpg" || $ext == ".png" || $ext == ".tif" || $ext == "jpeg")) {
+       if (substr($matches[0], 5, 4) ==  "http") {
+	   $pin_image = substr($matches[0], 5,-1);
+	   $og_image = substr($matches[0], 5,-1);
+	} else {
+     	   $pin_image = $uri->root() . substr($matches[0], 5,-1);
+     	   $og_image = $uri->root() . substr($matches[0], 5,-1);
+	}
      }
 }
 

--- a/meet_gavern/html/com_content/category/blog_item.php
+++ b/meet_gavern/html/com_content/category/blog_item.php
@@ -19,7 +19,15 @@ JHtml::_('behavior.framework');
 
 $templateParams = JFactory::getApplication()->getTemplate(true)->params;
 
-$aside_visible = ($params->get('show_modify_date')) or ($params->get('show_publish_date')) or ($params->get('show_hits')) or ($params->get('show_category')) or ($params->get('show_create_date')) or ($params->get('show_parent_category')) or ($params->get('show_author')) or $params->get('show_publish_date') or ($params->get('show_print_icon') || $params->get('show_email_icon') || $canEdit);
+$aside_visible = $params->get('show_modify_date') || 
+		 $params->get('show_publish_date') ||
+		 $params->get('show_hits') ||
+		 $params->get('show_category') ||
+		 $params->get('show_create_date') ||
+		 $params->get('show_parent_category') ||
+		 $params->get('show_author') || 
+		 $params->get('show_publish_date') || 
+		 ($canEdit || $params->get('show_print_icon') || $params->get('show_email_icon'));
 
 ?>
 <?php if ($this->item->state == 0) : ?>

--- a/meet_gavern/html/com_content/featured/default_item.php
+++ b/meet_gavern/html/com_content/featured/default_item.php
@@ -14,7 +14,15 @@ $params = &$this->item->params;
 $images = json_decode($this->item->images);
 $canEdit	= $this->item->params->get('access-edit');
 
-$aside_visible = ($params->get('show_modify_date')) or ($params->get('show_publish_date')) or ($params->get('show_hits')) or ($params->get('show_category')) or ($params->get('show_create_date')) or ($params->get('show_parent_category')) or ($params->get('show_author')) or $params->get('show_publish_date') or ($params->get('show_print_icon') || $params->get('show_email_icon') || $canEdit);
+$aside_visible = $params->get('show_modify_date') || 
+		 $params->get('show_publish_date') ||
+		 $params->get('show_hits') ||
+		 $params->get('show_category') ||
+		 $params->get('show_create_date') ||
+		 $params->get('show_parent_category') ||
+		 $params->get('show_author') || 
+		 $params->get('show_publish_date') || 
+		 ($canEdit || $params->get('show_print_icon') || $params->get('show_email_icon'));
 
 ?>
 <?php if ($this->item->state == 0) : ?>


### PR DESCRIPTION
Hi, this fixes the featured and category layout where the article info wasn't displayed any more.
It also changed the way og:image is filled. If there is no article image set, it will take the first image in the article itself. If no article found, it will take the websites logo for og:image.
Please note that facebook cannot handle (larger) webpages that are gzipped > if you have gzip enabled Facebook cannot find the og: parameters that it needs to construct the shared message. You need to disable gzip for your website.
hope this helps! regards,
Ruud.
