### PR TITLE
replace 'old' jquery with newer one

### DIFF
--- a/meet_gavern/layouts/default.php
+++ b/meet_gavern/layouts/default.php
@@ -81,7 +81,7 @@ if ($this->API->modules('sidebar')) {
 	<?php endif; ?>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	
-	<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+	<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
 	<script type="text/javascript">jQuery.noConflict();</script>
 	<jdoc:include type="head" />
 	<?php $this->layout->loadBlock('head'); ?>


### PR DESCRIPTION
Hi, was running into issues with a component that did not work with the jquery inserted by meetgavern.
I think using the newer one will prevent from this to happen more often in the future.
I am running this change on my production site now, not sure if it breaks something (not sure how and what to test other then just using it :))
Hope this helps!