### PR TITLE
Fix for ignoring Two Factor Authentication setting on login form

### DIFF
--- a/meet_gavern/html/com_users/login/default_login.php
+++ b/meet_gavern/html/com_users/login/default_login.php
@@ -67,7 +67,7 @@ $templateParams = JFactory::getApplication()->getTemplate(true)->params;
 					</div>
 				<?php endif; ?>
 			<?php endforeach; ?>
-			<?php if (property_exists($this,'tfa')): ?>
+			<?php if ($this->tfa): ?>
 				<div class="control-group">
 					<div class="control-label">
 						<?php echo $this->form->getField('secretkey')->label; ?>


### PR DESCRIPTION
Hi,
yesterday a new member of my site pointed out that after creating a new account he was asked for a username, password and a secret key.
I tested and it turns out that Meet_Gavern template has a bug in that it always asks for the secret key (used for Two Way Authentication) > the condition for testing if TWA is enabled didn't work.

this PR fixes that :)

Hope it helps!
![secret](https://cloud.githubusercontent.com/assets/2733197/11146634/481dedc6-8a10-11e5-84f3-e31836b9ad59.png)
