### PR TITLE
Update jquery to Joomla 3.6.x supported version

### DIFF
--- a/meet_gavern/layouts/default.php
+++ b/meet_gavern/layouts/default.php
@@ -83,7 +83,7 @@ if ($this->API->modules('sidebar')) {
 	<?php endif; ?>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	
-	<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+	<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 	<script type="text/javascript">jQuery.noConflict();</script>
 	<jdoc:include type="head" />
 	<?php $this->layout->loadBlock('head'); ?>


### PR DESCRIPTION
Was having issues with unsupported version 1.11.3, so decided it was time for an upgrade :)
btw, is there a reason why the file comes from externally hosted environment and not from ./media/jui/js (Joomla installed version)?