### PR TITLE
Update default.php

### DIFF
--- a/meet_gavern/layouts/default.php
+++ b/meet_gavern/layouts/default.php
@@ -238,7 +238,7 @@ if ($this->API->modules('sidebar')) {
 // Rules to remove predefined jQuery and Bootstrap and MooTools More
 GKParser::$customRules['/<script src="(.*?)media\/jui\/js\/jquery.min.js" type="text\/javascript"><\/script>/mi'] = '';
 GKParser::$customRules['/<script src="(.*?)media\/jui\/js\/jquery-noconflict.js" type="text\/javascript"><\/script>/mi'] = '';
-GKParser::$customRules['/<script src="(.*?)media\/jui\/js\/bootstrap.min.js" type="text\/javascript"><\/script>/mi'] = '';
+GKParser::$customRules['/<script src="(.*?)media\/jui\/js\/bootstrap.min.js(.*?)" type="text\/javascript"><\/script>/mi'] = '';
 //GKParser::$customRules['/<script src="(.*?)media\/system\/js\/mootools-more.js" type="text\/javascript"><\/script>/mi'] = '';
 
 // EOF


### PR DESCRIPTION
Fix for Joomla 3.7
Joomla 3.7 loads bootstrap.min.js with version number. Because this was not detected bootstrap was loaded twice resulting in errors (e.g. login button / modal not working any more)